### PR TITLE
Render properly in Chrome

### DIFF
--- a/Invoke-SuiteReport.ps1
+++ b/Invoke-SuiteReport.ps1
@@ -54,7 +54,7 @@ foreach ($UnitTest in $NUnitHtml) {
         #Find the exact url formatted path of the current CSS/JS file
         $urlTypePath = $regex.matches($content) | foreach {$_.groups['url'].value}
     
-        $content = $regex.Replace($content,$path)
+        $content = $regex.Replace($content,"'$path'")
         
         $content = ($content -replace 'ReportUnit TestRunner Report',"$ApplicationSuiteTitle") `
                              -replace 'Executive Summary',"Infrastrcture Test Suite for $ApplicationSuiteTitle" `

--- a/Invoke-SuiteReport.ps1
+++ b/Invoke-SuiteReport.ps1
@@ -63,6 +63,6 @@ foreach ($UnitTest in $NUnitHtml) {
         # Change url format to file format relative to script location
     } # end foreach URL replace
 
-    Out-File -InputObject $content -FilePath "$OutputFolder\$OutputHTML" -Force
+    Out-File -InputObject $content -FilePath "$OutputFolder\$OutputHTML" -Force -Encoding 'utf8'
     
 } # end Foreach unittests


### PR DESCRIPTION
The dependency on ActiveX seemed odd. Looking inside of the code base I did not see any ActiveX dependencies but the page was still not loading correctly in chrome. 

The cause of that is that by default the HTML files are saved in encoding different from UTF8 which makes chrome parse the linked JS and CSS files incorrectly. That in turn causes the page to load without charts (and any css what so ever). 

So I fixed that way the files are saved, and also fixed quoting to comply better with HTML, even though both chrome and edge guess correctly what you wanted to do. 

You might want to regenerate the example html files to reflect the new encoding. I did not want to do that, because it included my paths and mudded up the purpose of this PR.
